### PR TITLE
Fix production config

### DIFF
--- a/tdm-be/config/development.json
+++ b/tdm-be/config/development.json
@@ -2,8 +2,8 @@
     "hosts": {
         "internal": {
             "comment": "don't put https://",
-            "hostExample": "b562-88-123-62-113.ngrok-free.app",
             "host": "{ngrok host}",
+            "hostExample": "363f-88-123-62-113.ngrok-free.app",
             "isHttps": true
         },
         "external": {
@@ -30,7 +30,7 @@
             "enricher": "https://data-workflow.services.istex.fr/v1/base-line",
             "retrieve": "/v1/retrieve-csv",
             "retrieveExtension": "csv",
-            "summary": "**BaseLine** - Opération blanche - json -> csv",
+            "summary": "**BaseLine** - Opération blanche",
             "description": "Opération blanche pour tester le flux."
         },
         {
@@ -40,8 +40,22 @@
             "enricher": "https://data-workflow.services.istex.fr/v1/pdf-text",
             "retrieve": "/v1/retrieve-txt",
             "retrieveExtension": "txt",
-            "summary": "**textExtract** - Transforme un PDF en texte - pdf -> txt",
-            "description": "Transforme un PDF en texte en excluant les éléments qui perturberaient un traitement de fouille de texte ultérieur. Le PDF ne doit pas être un PDF image."
+            "summary": "**textExtract** - Transforme un PDF en texte",
+            "description": "Transforme un PDF en texte en excluant les éléments qui perturberaient un traitement de fouille de texte ultérieur.\n\nLe PDF ne doit pas être un PDF image.",
+            "descriptionLink": "https://services.istex.fr/extraction-du-texte-epure-de-pdf/"
+        },
+        {
+            "input": "corpus",
+            "inputFormat": "json",
+            "wrapper": "/v1/istex-tar-gz",
+            "wrapperParameter": "value",
+            "wrapperParameterDefault": "abstract",
+            "enricher": "https://data-workflow.services.istex.fr/v1/tag-cloud-en",
+            "retrieve": "/v1/retrieve-csv",
+            "retrieveExtension": "csv",
+            "summary": "**Teeft** - Extrait des termes pertinents de textes en anglais",
+            "description": "Extrait les 5 termes les plus spécifiques de chacun des textes en anglais. Permet d'avoir une idée de ce dont il est question dans chaque texte.\n\nL'entrée est un fichier corpus de ISTEX Search contenant les métadonnées JSON. Ce sont les *abstract*s qui seront analysés.",
+            "descriptionLink": "https://services.istex.fr/extraction-de-termes-teeft/"
         }
     ]
 }

--- a/tdm-be/config/production.json
+++ b/tdm-be/config/production.json
@@ -73,6 +73,8 @@
             "input": "corpus",
             "inputFormat": "json",
             "wrapper": "/v1/istex-tar-gz",
+            "wrapperParameter": "value",
+            "wrapperParameterDefault": "abstract",
             "enricher": "https://data-workflow.services.istex.fr/v1/tag-cloud-fr",
             "retrieve": "/v1/retrieve-csv",
             "retrieveExtension": "csv",

--- a/tdm-be/config/production.json
+++ b/tdm-be/config/production.json
@@ -32,8 +32,9 @@
             "enricher": "https://data-workflow.services.istex.fr/v1/bibcheck-pdf",
             "retrieve": "/v1/retrieve-csv",
             "retrieveExtension": "csv",
-            "summary": "**bibCheck** - Contrôle de références bibliographiques - pdf -> csv",
-            "description": "Contrôle les références bibliographiques d'un article en PDF, en vérifiant leur présence dans Crossref tout en s'assurant que l'article associé n'est pas rétracté."
+            "summary": "**bibCheck** - Contrôle de références bibliographiques",
+            "description": "Contrôle les références bibliographiques d'un article en PDF, en vérifiant leur présence dans Crossref tout en s'assurant que l'article associé n'est pas rétracté.",
+            "descriptionLink": "https://services.istex.fr/validation-de-reference-bibliographique/"
         },
         {
             "input": "article",
@@ -42,8 +43,9 @@
             "enricher": "https://data-workflow.services.istex.fr/v1/pdf-text",
             "retrieve": "/v1/retrieve-txt",
             "retrieveExtension": "txt",
-            "summary": "**textExtract** - Transforme un PDF en texte - pdf -> txt",
-            "description": "Transforme un PDF en texte en excluant les éléments qui perturberaient un traitement de fouille de texte ultérieur.\n\nLe PDF ne doit pas être un PDF image."
+            "summary": "**textExtract** - Transforme un PDF en texte",
+            "description": "Transforme un PDF en texte en excluant les éléments qui perturberaient un traitement de fouille de texte ultérieur.\n\nLe PDF ne doit pas être un PDF image.",
+            "descriptionLink": "https://services.istex.fr/extraction-du-texte-epure-de-pdf/"
         },
         {
             "input": "corpus",
@@ -54,8 +56,9 @@
             "enricher": "https://data-workflow.services.istex.fr/v1/tag-cloud-en",
             "retrieve": "/v1/retrieve-csv",
             "retrieveExtension": "csv",
-            "summary": "**Teeft** - Extrait des termes pertinents de textes en anglais - istex.tar.gz -> csv",
-            "description": "Extrait les 5 termes les plus spécifiques de chacun des textes en anglais. Permet d'avoir une idée de ce dont il est question dans chaque texte.\n\nL'entrée est un fichier corpus de ISTEX Search contenant les métadonnées JSON. Ce sont les *abstract*s qui seront analysés."
+            "summary": "**Teeft** - Extrait des termes pertinents de textes en anglais",
+            "description": "Extrait les 5 termes les plus spécifiques de chacun des textes en anglais. Permet d'avoir une idée de ce dont il est question dans chaque texte.\n\nL'entrée est un fichier corpus de ISTEX Search contenant les métadonnées JSON. Ce sont les *abstract*s qui seront analysés.",
+            "descriptionLink": "https://services.istex.fr/extraction-de-termes-teeft/"
         },
         {
             "input": "corpus",
@@ -66,8 +69,9 @@
             "enricher": "https://data-workflow.services.istex.fr/v1/tag-cloud-en",
             "retrieve": "/v1/retrieve-csv",
             "retrieveExtension": "csv",
-            "summary": "**Teeft** - Extrait des termes pertinents de textes en anglais - csv -> csv",
-            "description": "Extrait les 5 termes les plus spécifiques de chacun des textes en anglais. Permet d'avoir une idée de ce dont il est question dans chaque texte.\n\nL'entrée est un fichier CSV avec une colonne de texte en anglais. Par défaut c'est la colonne `value` qui est prise. On peut saisir le nom de la colonne à traiter."
+            "summary": "**Teeft** - Extrait des termes pertinents de textes en anglais",
+            "description": "Extrait les 5 termes les plus spécifiques de chacun des textes en anglais. Permet d'avoir une idée de ce dont il est question dans chaque texte.\n\nL'entrée est un fichier CSV avec une colonne de texte en anglais. Par défaut c'est la colonne `value` qui est prise. On peut saisir le nom de la colonne à traiter.",
+            "descriptionLink": "https://services.istex.fr/extraction-de-termes-teeft/"
         },
         {
             "input": "corpus",
@@ -78,8 +82,9 @@
             "enricher": "https://data-workflow.services.istex.fr/v1/tag-cloud-fr",
             "retrieve": "/v1/retrieve-csv",
             "retrieveExtension": "csv",
-            "summary": "**Teeft** - Extrait 5 termes de textes en français - istex.tar.gz -> csv",
-            "description": "Extrait les 5 termes les plus spécifiques de chacun des *abstract*s en français. Permet d'avoir une idée de ce dont il est question dans chaque texte.\n\nL'entrée est un fichier corpus de ISTEX Search contenant les métadonnées JSON. Ce sont les *abstract*s qui seront analysés."
+            "summary": "**Teeft** - Extrait 5 termes de textes en français",
+            "description": "Extrait les 5 termes les plus spécifiques de chacun des *abstract*s en français. Permet d'avoir une idée de ce dont il est question dans chaque texte.\n\nL'entrée est un fichier corpus de ISTEX Search contenant les métadonnées JSON. Ce sont les *abstract*s qui seront analysés.",
+            "descriptionLink": "https://services.istex.fr/extraction-de-termes-teeft/"
         },
         {
             "input": "corpus",
@@ -90,8 +95,9 @@
             "enricher": "https://data-workflow.services.istex.fr/v1/tag-cloud-en",
             "retrieve": "/v1/retrieve-csv",
             "retrieveExtension": "csv",
-            "summary": "**Teeft** - Extrait 5 termes de textes en français - csv -> csv",
-            "description": "Extrait les 5 termes les plus spécifiques de chacun des textes en français. Permet d'avoir une idée de ce dont il est question dans chaque texte.\n\nL'entrée est un fichier CSV avec une colonne de texte en français. Par défaut c'est la colonne `value` qui est prise. On peut saisir le nom de la colonne à traiter."
+            "summary": "**Teeft** - Extrait 5 termes de textes en français",
+            "description": "Extrait les 5 termes les plus spécifiques de chacun des textes en français. Permet d'avoir une idée de ce dont il est question dans chaque texte.\n\nL'entrée est un fichier CSV avec une colonne de texte en français. Par défaut c'est la colonne `value` qui est prise. On peut saisir le nom de la colonne à traiter.",
+            "descriptionLink": "https://services.istex.fr/extraction-de-termes-teeft/"
         }
     ]
 }

--- a/tdm-be/src/worker/enrichmentHook.ts
+++ b/tdm-be/src/worker/enrichmentHook.ts
@@ -96,6 +96,7 @@ const enrichmentHookSuccess = async (processingId: string) => {
                 responseType: 'arraybuffer',
             },
         );
+        debug(processingId, 'Enrichment-Hook api ${enrichmentEntry.url}/${enrichmentEntry.retrieveUrl.url} called');
     } catch (e) {
         const message = `Impossible to contact enrichment-hook api (${enrichmentEntry.url} / ${enrichmentEntry.retrieveUrl.url})`;
         error(processingId, message);


### PR DESCRIPTION
`istex-tar-gz` utilise un paramètre, qui devrait être à `abtract` par défaut.

Je pensais que IA-Factory ne forçait pas les paramètres (c'est-à-dire que les paramètres par défaut des web services s'appliquaient), mais ça semble ne pas être le cas.

Il faut donc tout expliciter.